### PR TITLE
fix: include Firefox browser default color in focus-highlight tachyon's outline style [SRED-168]

### DIFF
--- a/src/random.css
+++ b/src/random.css
@@ -452,7 +452,8 @@
   /** sticky bar slide in */
   
   .focus-highlight:focus {
-    outline: -webkit-focus-ring-color auto 1px;
+    outline: auto 1px Highlight;
+    outline: auto 1px -webkit-focus-ring-color;
   }
   
   .will-change-height {


### PR DESCRIPTION
Considering this a draft PR for now - still doing research but seems like this may be [the best solution](https://css-tricks.com/copy-the-browsers-native-focus-styles/)