### PR TITLE
fix: modify modern-normalize css to remove firefox dotted focus outline override [SRED-163]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@washingtonpost/motion-tokens": "latest",
         "@washingtonpost/shadow-tokens": "latest",
         "@washingtonpost/spacing-tokens": "latest",
-        "@washingtonpost/typography-tokens": "latest",
-        "modern-normalize": "^2.0.0"
+        "@washingtonpost/typography-tokens": "latest"
       },
       "devDependencies": {
         "cssnano": "^5.1.15",
@@ -3508,17 +3507,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/modern-normalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-2.0.0.tgz",
-      "integrity": "sha512-CxBoEVKh5U4DH3XuNbc5ONLF6dQBc8dSc7pdZ1957FGbIO5JBqGqqchhET9dTexri8/pk9xBL6+5ceOtCIp1QA==",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mri": {
@@ -8228,11 +8216,6 @@
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
       }
-    },
-    "modern-normalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-2.0.0.tgz",
-      "integrity": "sha512-CxBoEVKh5U4DH3XuNbc5ONLF6dQBc8dSc7pdZ1957FGbIO5JBqGqqchhET9dTexri8/pk9xBL6+5ceOtCIp1QA=="
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@washingtonpost/motion-tokens": "latest",
     "@washingtonpost/shadow-tokens": "latest",
     "@washingtonpost/spacing-tokens": "latest",
-    "@washingtonpost/typography-tokens": "latest",
-    "modern-normalize": "^2.0.0"
+    "@washingtonpost/typography-tokens": "latest"
   },
   "peerDependencies": {
     "@washingtonpost/icon-tokens": "latest",

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import '../node_modules/modern-normalize/modern-normalize.css';
+@import "./normalize.css";
 @import "./variables.css";
 @import "./unstable-theme.css";
 @import "./borders.css";

--- a/src/nextra.css
+++ b/src/nextra.css
@@ -3,7 +3,7 @@
 
     does not include normalize, shame, header, or tooltip
 */
-/* @import '../node_modules/modern-normalize/modern-normalize.css'; */
+/* @import "./normalize.css"; */
 @import "./wpds-colors-tokens.css";
 @import "./variables.css";
 @import "./unstable-theme.css";

--- a/src/normalize.css
+++ b/src/normalize.css
@@ -1,0 +1,268 @@
+/*! modern-normalize v2.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/* NOTE: This is a manually modified version of the css from the above GitHub repo */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+	box-sizing: border-box;
+}
+
+html {
+	/* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
+	font-family:
+		system-ui,
+		'Segoe UI',
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji';
+	line-height: 1.15; /* 1. Correct the line height in all browsers. */
+	-webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
+	-moz-tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
+	tab-size: 4; /* 3 */
+}
+
+/*
+Sections
+========
+*/
+
+body {
+	margin: 0; /* Remove the margin in all browsers. */
+}
+
+/*
+Grouping content
+================
+*/
+
+/**
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+*/
+
+hr {
+	height: 0; /* 1 */
+	color: inherit; /* 2 */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr[title] {
+	text-decoration: underline dotted;
+}
+
+/**
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+	font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+	font-family:
+		ui-monospace,
+		SFMono-Regular,
+		Consolas,
+		'Liberation Mono',
+		Menlo,
+		monospace; /* 1 */
+	font-size: 1em; /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+	font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+
+sub {
+	bottom: -0.25em;
+}
+
+sup {
+	top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+	text-indent: 0; /* 1 */
+	border-color: inherit; /* 2 */
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+	font-family: inherit; /* 1 */
+	font-size: 100%; /* 1 */
+	line-height: 1.15; /* 1 */
+	margin: 0; /* 2 */
+}
+
+/**
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+	text-transform: none;
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+	-webkit-appearance: button;
+}
+
+/**
+Remove the inner border and padding in Firefox.
+*/
+
+::-moz-focus-inner {
+	border-style: none;
+	padding: 0;
+}
+
+/**
+Remove the additional ':invalid' styles in Firefox.
+See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737
+*/
+
+:-moz-ui-invalid {
+	box-shadow: none;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+	padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+	vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+	height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+	-webkit-appearance: textfield; /* 1 */
+	outline-offset: -2px; /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+	-webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+	-webkit-appearance: button; /* 1 */
+	font: inherit; /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+	display: list-item;
+}


### PR DESCRIPTION
This fixes a regression noticed in spectrum on Firefox, where the expected blue focus ring was being overridden by a dotted black line from modern-normalize:

https://github.com/washingtonpost/tachyons-css/assets/38192823/f6eaf64c-76f4-4cbf-8019-bb24b370f596

We fix this by removing the offending style and housing the modern normalize css in-house instead of importing from a package.